### PR TITLE
Revision jlehtoma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 *.Rproj
 *.html
+*.pdf

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -3,9 +3,6 @@
   arxivId =	 {1609.00037},
   author =	 {Wilson, Greg and Bryan, Jenny and Cranston, Karen and Kitzes, Justin and Nederbragt, Lex and Teal, Tracy},
   eprint =	 {1609.00037},
-  file =
-                  {:home/jlehtoma/Dropbox/Documents/Mendeley/2016/Wilson
-                  et al.{\_}2016(2).pdf:pdf},
   pages =	 {1--30},
   title =	 {{Good Enough Practices for Scientific Computing}},
   year =	 {2016}

--- a/comments.md
+++ b/comments.md
@@ -1,4 +1,9 @@
 ## Joona (2017-03-31)
 
++ Perhaps we can leave the title "Ten simple rules..." for the possible manuscript? This way we pull less emphasis on the rules themselves. It would be ok to concentrate on the rules, but then I think we would need to come up with a more cohesive group of rules. 
+
 + I would talk about "programming" rather than "statistical programming", *unless* we really want to concentrate on the statistical aspects (I don't).
-+ 
+
++ "Learners" rather than "students". To me, "students" refers too much to actual education (i.e. school, university etc), whereas "learner" is broader and more inclusive term.
+
++ The order of rules needs to be checked once the actual scope is decided. I didn't touch these yet as it was not completely clear what the scope actually will be. 

--- a/comments.md
+++ b/comments.md
@@ -1,0 +1,4 @@
+## Joona (2017-03-31)
+
++ I would talk about "programming" rather than "statistical programming", *unless* we really want to concentrate on the statistical aspects (I don't).
++ 

--- a/user-2017-ropengov-abstract.md
+++ b/user-2017-ropengov-abstract.md
@@ -1,5 +1,5 @@
 ---
-title: "Ten simple rules for learning statistical programming"
+title: "Grassroot level learning and knowledge sharing in R"
 author:
   Lahti L^1^, Lehtomäki J^2^, and Kainu M^3
   $^1$Department of Mathematics and Statistics, University of Turku, Finland
@@ -14,25 +14,27 @@ bibliography:
 
 **Webpages**: [https://ropengov.github.io](https://ropengov.github.io)
 
+R is increasingly used in learning to entry-level programming in universities, research institutes, public sector offices and private companies. In addition, many researchers and data scientists are developing educational resources in R, such as open tutorial collections [@Kamvar2017 ; @Lahti2017], exercise materials [REF?] or presentation slides [REF?]. In addition, initiatives such as Data Carpentry [REF?] and Software Carpentry [REF?] have already facilitated the learning process greatly. By pooling the material and experience from these personal and collective experiences, we can further facilitate the uptake of computational tools in various institutions. Simple, ready-made templates can be used as a starting point to expose the learners rapidly to the available tools and best practices in programming, collaborative development models, and the principles of open science. Based on our combined experience from universities, research institues, and the public sector, we have collected a set of ten simple rules, aiming to summarize key ingredients for successful teaching of modern computational science, facilitated by the versatile toolkit that the R ecosystem and its active user communities can provide. 
 
-In addition to providing a powerful environment for statistical programming, R is increasingly used as a tool to facilitate modern interactive learning in statistics courses, where the student acquire skills based on a problem-solving approach. An increasing number of researchers are developing educational resources in R, such as open tutorial collections [@Kamvar2017 ; @Lahti2017], exercise materials [REF?] or presentation slides [REF?]. Simple, ready-made templates can be used as a starting point to expose the students rapidly to the available tools and best practices in statistical programming, collaborative development models, and the principles of open science, for instance. Based on our combined experience from universities, research institues, and the public sector, we have collected a set of ten simple rules, aiming to summarize key ingredients for successful teaching of modern computational science, facilitated by the versatile toolkit that the R ecosystem and its active user communities can provide. 
+1. **Levels of teaching** As in all teaching, it is essential to identify the learners’ prior knowledge and the overall learning goals. Many aspects enabled by R can be better appreciated by advanced statisticians than those who are still learning the basics of programming. Moreover, the academia and public sector institutions, for example, have different needs.
 
-1. **Levels of teaching** As in all teaching, it is essential to identify the students’ prior knowledge and the overall learning goals. Many aspects enabled by R can be better appreciated by advanced statisticians than those who are still learning the basics of programming. Moreover, the academia and public sector institutions may have different needs.
-
-2. **Interactive learning** Students can start from a simple Rmarkdown workflow and expand that.
+2. **Interactive learning** Students can start from a simple Rmarkdown workflow and expand that. 
 
 3. **Getting things done fast** Avoid the trap of many programs and get the feeling of success. Reproducible research / workflows. Potential of R packages (targeted tools, open science, reproducible research) easier to explain to experienced statisticians that have years of experience on repetitive tasks; compared to undergraduate students. 
 
 4. **Open science**
 
-5. **Best practices** Good Enough Practices for Scientific Computing @Wilson2016 / Tidy data principles
+5. **Best practices** Good Enough Practices for Scientific Computing [@Wilson2016] / Tidy data principles
 
-6. **Code review**
+6. **Code review** Existing experience in the research/work community and knowledge sharing can be leveraged by using simple fork - pull request - code review model enabled by Github.
 
 7. **Open collaboration model** If teaching is coupled with open collaboration model ie. straight from start using custom built R package, this can highlight the open development model and its dynamic potential. Not just a free replacement for commercial stats software but a collaborative platform for developing solutions and utilities, including ggplot themes, raport templates, rstudio-add-ins, shiny-modules, database functions etc.
 
 8. **Educational resources** Document and archive course materials on Github and Canvas using modern sustainable techniques that facilitate collaboration and sharing. 
 
+9. **Domain specificity** Facilitating learning and knowledge sharing on grassroot level means, that the teaching experience can be very domain specific and hence very relevant for the learners. However, this also poses challenges for developing common processes and materials.
+
+10. **Show-and-tell culture** Actively promote sharing experiences of both how people learn R and how they have solved specific problems. Informal meetings, online communication channels (e.g. Slack, IRC, Facebook) and hackathons can all be leveraged to help sharing individual experiences.
 
 In summary, R community could better support teaching with R by.. collections of open teaching materials, sharing best practices etc..
 

--- a/user-2017-ropengov-abstract.md
+++ b/user-2017-ropengov-abstract.md
@@ -1,9 +1,9 @@
 ---
 title: "Ten simple rules for learning statistical programming"
 author:
-  Lahti L^1^, Lehtomäki J^2^, and Kainu M^3^
+  Lahti L^1^, Lehtomäki J^2^, and Kainu M^3
   $^1$Department of Mathematics and Statistics, University of Turku, Finland
-  $^2$Tus Place
+  $^2$Department of Earth Sciences, VU Amsterdam
 output:
   pdf_document
 bibliography:


### PR DESCRIPTION
Good start, thanks @antagomir ! I made some modifications along the lines of what I had in mind, but to decision on the actual scope is of course yours. So don't merge right away! The main comments are the following.

+ Perhaps we can leave the title "Ten simple rules..." for the possible manuscript? This way we pull less emphasis on the rules themselves. It would be OK to concentrate on the rules, but then I think we would need to come up with a more cohesive group of rules. 

+ I would talk about "programming" rather than "statistical programming", *unless* we really want to concentrate on the statistical aspects (I don't).

+ "Learners" rather than "students". To me, "students" refers too much to actual education (i.e. school, university etc), whereas "learner" is broader and more inclusive term.

+ The order of rules needs to be checked once the actual scope is decided. I didn't touch these yet as it was not completely clear what the scope actually will be. 
